### PR TITLE
types and docs update

### DIFF
--- a/docs/components/date-picker.md
+++ b/docs/components/date-picker.md
@@ -22,6 +22,8 @@ The `<DatePicker />`component gives your a easy-to-use cross platform date picke
 
 ### Setup dependencies
 
+Install @react-native-community/datetimepicker dependency : `npm i @react-native-community/datetimepicker`.
+
 Since this components uses a backdrop, you need to wrap your application with a `<BackdropProvider />` component. You usually want to wrap it as high as possible in your tree so that the backdrop properly covers the whole screen.
 
 ```tsx

--- a/packages/backdrop-provider/src/BackdropProvider.tsx
+++ b/packages/backdrop-provider/src/BackdropProvider.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import React, {FunctionComponent, PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Animated, Easing, EasingFunction, Platform, StyleSheet} from 'react-native';
 const IOS_OPACITY = 0.25; // @NOTE from native ActionSheet backdrop
 
@@ -29,7 +29,7 @@ export const defaultProps: Required<BackdropProviderProps> = {
   zIndex: 99
 };
 
-export const BackdropProvider: FunctionComponent<BackdropProviderProps> = ({
+export const BackdropProvider: FunctionComponent<PropsWithChildren<BackdropProviderProps>> = ({
   backgroundColor = 'black',
   children,
   duration = defaultProps.duration,


### PR DESCRIPTION
Since React 18 removed the implicit `children` type from FunctionComponent (see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210), this is a small type update related to that.  